### PR TITLE
main: add a bit of output to -q

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 	_, fail := runner.Results.PassFail()
 	if fail > 0 {
-		fmt.Printf("%d issues to fix\n", fail)
+		fmt.Printf("%d commits to fix\n", fail)
 		os.Exit(1)
 	}
 

--- a/validate/runner.go
+++ b/validate/runner.go
@@ -77,6 +77,13 @@ func (r *Runner) Run() error {
 		r.Results = append(r.Results, vr...)
 		_, fail := vr.PassFail()
 		if os.Getenv("QUIET") != "" {
+			if fail != 0 {
+				for _, res := range vr {
+					if !res.Pass {
+						fmt.Printf(" %s - FAIL - %s\n", commit["abbreviated_commit"], res.Msg)
+					}
+				}
+			}
 			// everything else in the loop is printing output.
 			// If we're quiet, then just continue
 			continue


### PR DESCRIPTION
ideally `-q` would be only return code of 0 or non-zero, but it already
had some output. This adds only failed tests per commit.

Signed-off-by: Vincent Batts vbatts@hashbangbash.com
