### PR TITLE
Test merges again and return to using TRAVIS_COMMIT_RANGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - mkdir -p $GOPATH/src/github.com/vbatts && ln -sf $(pwd) $GOPATH/src/github.com/vbatts/git-validation && go get ./...
 
 before_script:
+  - echo $TRAVIS_COMMIT_RANGE
   - echo $TRAVIS_COMMIT
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_TAG

--- a/git/commits.go
+++ b/git/commits.go
@@ -12,7 +12,7 @@ import (
 // If commitrange is a git still range 12345...54321, then it will be isolated set of commits.
 // If commitrange is a single commit, all ancestor commits up through the hash provided.
 func Commits(commitrange string) ([]CommitEntry, error) {
-	cmdArgs := []string{"git", "--no-pager", "log", `--no-merges`, `--pretty=format:%H`, commitrange}
+	cmdArgs := []string{"git", "--no-pager", "log", `--pretty=format:%H`, commitrange}
 	if debug() {
 		logrus.Infof("[git] cmd: %q", strings.Join(cmdArgs, " "))
 	}

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 	var commitRange = *flCommitRange
 	if commitRange == "" {
 		if strings.ToLower(os.Getenv("TRAVIS")) == "true" && !*flNoTravis {
-			if os.Getenv("TRAVIS_BRANCH") != "" {
-				commitRange = fmt.Sprintf("%s..FETCH_HEAD", os.Getenv("TRAVIS_BRANCH"))
+			if os.Getenv("TRAVIS_COMMIT_RANGE") != "" {
+				commitRange = strings.Replace("...", "..", os.Getenv("TRAVIS_COMMIT_RANGE"), 1)
 			} else if os.Getenv("TRAVIS_COMMIT") != "" {
 				commitRange = os.Getenv("TRAVIS_COMMIT")
 			}


### PR DESCRIPTION
Partially revert #15 and #16.  #15 breaks when FETCH_HEAD doesn't exist (more in opencontainers/runC#1383) and #16 was a patch over the updated #15 commit range.

This commit adds the workaround for travis-ci/travis-ci#4596 which runtime-spec has been using since opencontainers/runtime-spec#216.

More details on the changes in the commit messages, if folks are particularly curious.