### PR TITLE
main: Fix strings.Replace argument order

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	if commitRange == "" {
 		if strings.ToLower(os.Getenv("TRAVIS")) == "true" && !*flNoTravis {
 			if os.Getenv("TRAVIS_COMMIT_RANGE") != "" {
-				commitRange = strings.Replace("...", "..", os.Getenv("TRAVIS_COMMIT_RANGE"), 1)
+				commitRange = strings.Replace(os.Getenv("TRAVIS_COMMIT_RANGE"), "...", "..", 1)
 			} else if os.Getenv("TRAVIS_COMMIT") != "" {
 				commitRange = os.Getenv("TRAVIS_COMMIT")
 			}


### PR DESCRIPTION
It's [`(string, old, new, n)`][1], not `(old, new, string, n)`.  Sorry about that :/.

[1]: https://golang.org/pkg/strings/#Replace