### PR TITLE
Add exclude pattern for git checks

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -61,7 +62,14 @@ var FieldNames = map[string]string{
 // Check warns if changes introduce whitespace errors.
 // Returns non-zero if any issues are found.
 func Check(commit string) ([]byte, error) {
-	cmd := exec.Command("git", "--no-pager", "show", "--check", commit)
+	args := []string{
+		"--no-pager", "log", "--check",
+		fmt.Sprintf("%s^..%s", commit, commit),
+	}
+	if exclude := os.Getenv("GIT_CHECK_EXCLUDE"); exclude != "" {
+		args = append(args, "--", ".", fmt.Sprintf(":(exclude)%s", exclude))
+	}
+	cmd := exec.Command("git", args...)
 	if debug() {
 		logrus.Infof("[git] cmd: %q", strings.Join(cmd.Args, " "))
 	}


### PR DESCRIPTION
Allows excluding of vendor directories for whitespace checks

see failure for https://github.com/containerd/containerd/pull/771
```
$ TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
git-validation -q -run DCO,short-subject,dangling-whitespace
 fcef902 - FAIL - has whitespace errors. See `git show --check fcef902aa5583e3efde5456562fd84e09c835258`.
1 commits to fix
make: *** [dco] Error 1
```

The problem was in a vendored README
```
vendor/github.com/godbus/dbus/README.markdown:28: trailing whitespace.
+gives a short overview over the basic usage. 
```

This allows setting `GIT_CHECK_EXCLUDE="./vendor"` for go projects to exclude the check here