### PR TITLE
Skip empty excludes

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -108,6 +108,9 @@ func Check(commit string) ([]byte, error) {
 		if gitNewEnough {
 			excludeList := strings.Split(excludeEnvList, ":")
 			for _, exclude := range excludeList {
+				if exclude == "" {
+					continue
+				}
 				args = append(args, "--", ".", fmt.Sprintf(":(exclude)%s", exclude))
 			}
 		}


### PR DESCRIPTION
This is useful when you want to append additional elements to the env
var in the fasion of `PATH=$PATH:/things`.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>