### PR TITLE
Consider only commit IDs when listing range

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -15,7 +15,7 @@ import (
 // If commitrange is a single commit, all ancestor commits up through the hash provided.
 // If commitrange is an empty commit range, then nil is returned.
 func Commits(commitrange string) ([]CommitEntry, error) {
-	cmdArgs := []string{"git", "--no-pager", "log", `--pretty=format:%H`, commitrange}
+	cmdArgs := []string{"git", "rev-list", commitrange}
 	if debug() {
 		logrus.Infof("[git] cmd: %q", strings.Join(cmdArgs, " "))
 	}


### PR DESCRIPTION
Fixes #46

When using `git log`, if some/all commits are gpg-signed, git will
automatically try to validate the signatures by default.  This results
in printing additional text.  This additional gpg-validation text is
then incorrectly interpreted by `git-validate` as if they were commit
IDs.  Fix the problem by using the `rev-list` sub-command which will
ONLY list the IDs.

Signed-off-by: Chris Evich <cevich@redhat.com>