### PR TITLE
Replace CRLF in all commit messages which currently causes DCO check …

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -153,7 +153,8 @@ func LogCommit(commit string) (*CommitEntry, error) {
 			logrus.Errorf("[git] cmd: %q", strings.Join(cmd.Args, " "))
 			return nil, err
 		}
-		c[v] = strings.TrimSpace(string(out))
+		commitMessage := strings.ReplaceAll(string(out), "\r\n", "\n")
+		c[v] = strings.TrimSpace(commitMessage)
 	}
 
 	return &c, nil


### PR DESCRIPTION
Came across this issue where a CRLF in the git commit message was causing `git-validation` to fail
https://github.com/firecracker-microvm/firecracker-containerd/issues/619

This PR tries the fix the above issue by replacing any CRLF in the commit message upfront.


Example commit message:

```
commit 78381c382b17ac8c8ef6ffbfae27f65db8b186a7 (HEAD -> main, origin/main, origin/HEAD)
Author: Swagat Bora <swagatbora90@gmail.com>
Date:   Mon May 2 16:33:53 2022 -0700

    Allow configuration of block_device cache strategy in firecracker (#615)
    
    Signed-off-by: Swagat Bora <sbora@amazon.com>
    
    Co-authored-by: Swagat Bora <sbora@amazon.com>
```

Commit has the expected DCO, but `git-validation` still fails


***Current***

[ec2-user@ip-172-31-9-211 firecracker-containerd]$ ~/git-validation/main -run DCO,short-subject -range HEAD~1..HEAD
 * 78381c3 "Allow configuration of block_device cache strategy in firecracker (#615)" ... FAIL
  - FAIL - does not have a valid DCO
1 commits to fix


***After this change***

[ec2-user@ip-172-31-9-211 firecracker-containerd]$ ~/git-validation/main -run DCO,short-subject -range HEAD~1..HEAD
 * 78381c3 "Allow configuration of block_device cache strategy in firecracker (#615)" ... PASS
