### PR TITLE
git: explicitly don't validate the output of gpg signatures

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -57,7 +57,7 @@ func checkRevList(commitrange string) (string, error) {
 		// no issues, return now
 		return commitrange, nil
 	}
-	cmdArgs = []string{"git", "log", "--pretty=oneline"}
+	cmdArgs = []string{"git", "log", "--pretty=oneline", "--no-show-signature"}
 	if debug() {
 		logrus.Infof("[git] cmd: %q", strings.Join(cmdArgs, " "))
 	}


### PR DESCRIPTION
Fixes #64